### PR TITLE
Improvement: use c11 timespec_get instead of posix clock_gettime

### DIFF
--- a/json_test.cpp
+++ b/json_test.cpp
@@ -101,7 +101,7 @@ struct timespec
 now(void)
 {
     struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
+    timespec_get(&ts, TIME_UTC);
     return ts;
 }
 


### PR DESCRIPTION
Now we have a better choice: [`timespec_get`](https://en.cppreference.com/w/c/chrono/timespec_get)