### PR TITLE
make updates to compile on osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,18 @@
+# Compiler and flags
+CXX = c++
 CXXFLAGS = -std=c++11 -O
+AR = ar
 
-check:	json_test.ok			\
-	jsontestsuite_test.ok
+# Platform detection for archive flags
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S), Darwin) # macOS
+    ARFLAGS = rcs
+else # Assume GNU/Linux or compatible system
+    ARFLAGS = rcsD
+endif
+
+# Targets
+check: json_test.ok jsontestsuite_test.ok
 
 clean:
 	rm -f *.o *.a *.ok *_test *.elf *.dbg
@@ -11,15 +22,18 @@ json.o: json.cpp json.h
 
 fuzz.o: fuzz.cpp json.h
 fuzz: fuzz.o json.o double-conversion.a
+	$(CXX) $(CXXFLAGS) -o $@ $^
 
 json_test.o: json_test.cpp json.h
 json_test: json_test.o json.o double-conversion.a
+	$(CXX) $(CXXFLAGS) -o $@ $^
 
 jsontestsuite_test.o: jsontestsuite_test.cpp json.h
 jsontestsuite_test: jsontestsuite_test.o json.o double-conversion.a
+	$(CXX) $(CXXFLAGS) -o $@ $^
 
 %: %.o
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $(TARGET_ARCH) $(OUTPUT_OPTION) $^
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $(TARGET_ARCH) -o $@ $^
 
 %.ok: %
 	./$<
@@ -37,7 +51,7 @@ double-conversion.a:			\
 		fixed-dtoa.o		\
 		string-to-double.o	\
 		strtod.o
-	$(AR) rcsD $@ $^
+	$(AR) $(ARFLAGS) $@ $^
 
 %.o: double-conversion/%.cc
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c $<

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,7 @@
-# Compiler and flags
-CXX = c++
 CXXFLAGS = -std=c++11 -O
-AR = ar
 
-# Platform detection for archive flags
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S), Darwin) # macOS
-    ARFLAGS = rcs
-else # Assume GNU/Linux or compatible system
-    ARFLAGS = rcsD
-endif
-
-# Targets
-check: json_test.ok jsontestsuite_test.ok
+check:	json_test.ok			\
+	jsontestsuite_test.ok
 
 clean:
 	rm -f *.o *.a *.ok *_test *.elf *.dbg
@@ -22,18 +11,15 @@ json.o: json.cpp json.h
 
 fuzz.o: fuzz.cpp json.h
 fuzz: fuzz.o json.o double-conversion.a
-	$(CXX) $(CXXFLAGS) -o $@ $^
 
 json_test.o: json_test.cpp json.h
 json_test: json_test.o json.o double-conversion.a
-	$(CXX) $(CXXFLAGS) -o $@ $^
 
 jsontestsuite_test.o: jsontestsuite_test.cpp json.h
 jsontestsuite_test: jsontestsuite_test.o json.o double-conversion.a
-	$(CXX) $(CXXFLAGS) -o $@ $^
 
 %: %.o
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $(TARGET_ARCH) -o $@ $^
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $(TARGET_ARCH) $(OUTPUT_OPTION) $^
 
 %.ok: %
 	./$<
@@ -51,7 +37,7 @@ double-conversion.a:			\
 		fixed-dtoa.o		\
 		string-to-double.o	\
 		strtod.o
-	$(AR) $(ARFLAGS) $@ $^
+	$(AR) rcs $@ $^
 
 %.o: double-conversion/%.cc
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c $<


### PR DESCRIPTION
some small changes to pass `ar` flags in OSX when building. Feel free to drop any of the small formatting changes if they don't meet muster. Thanks for this lib! Superficial but it's nice to see the code compile and test before dropping into my project. 