### PR TITLE
-Wterminate warning fix

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -373,7 +373,7 @@ Json::operator=(const Json& other)
     return *this;
 }
 
-Json::Json(Json&& other) noexcept : type_(other.type_)
+Json::Json(Json&& other) : type_(other.type_)
 {
     switch (type_) {
         case Null:
@@ -401,13 +401,13 @@ Json::Json(Json&& other) noexcept : type_(other.type_)
               std::map<std::string, Json>(std::move(other.object_value));
             break;
         default:
-            ON_LOGIC_ERROR("Unhandled JSON type.");;
+            ON_LOGIC_ERROR("Unhandled JSON type.");
     }
     other.type_ = Null;
 }
 
 Json&
-Json::operator=(Json&& other) noexcept
+Json::operator=(Json&& other)
 {
     if (this != &other) {
         if (type_ >= String)

--- a/json.h
+++ b/json.h
@@ -92,7 +92,7 @@ class Json
     static std::pair<Status, Json> parse(const std::string&);
 
     Json(const Json&);
-    Json(Json&&) noexcept;
+    Json(Json&&);
     Json(unsigned long);
     Json(unsigned long long);
     Json(const char*);
@@ -203,7 +203,7 @@ class Json
     std::string toStringPretty() const;
 
     Json& operator=(const Json&);
-    Json& operator=(Json&&) noexcept;
+    Json& operator=(Json&&);
 
     Json& operator[](size_t);
     Json& operator[](const std::string&);


### PR DESCRIPTION
remove `noexcept`  keyword in `Json::Json(Json&& other)` and `Json& operator=(Json&&)`.