### PR TITLE
CMake improvements

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,11 +22,8 @@ jobs:
 
     strategy:
       matrix:
-        arch: [aarch64, ppc64le, s390x]
+        arch: [ppc64le, s390x]
         include:
-          - arch: aarch64
-            distro: ubuntu22.04
-            platform-name: linux/arm64
           - arch: ppc64le
             distro: ubuntu22.04
             platform-name: linux/ppc64le

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if (JSON_CPP_BUILD_TESTS)
     add_custom_command(
         TARGET jsontestsuite_test POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${CMAKE_SOURCE_DIR}/JSONTestSuite
+            ${CMAKE_CURRENT_SOURCE_DIR}/JSONTestSuite
             ${CMAKE_CURRENT_BINARY_DIR}/JSONTestSuite
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(jtjson)
 
+option(JSON_CPP_BUILD_TESTS "Enable building tests" ON)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -25,27 +27,30 @@ target_link_libraries(json PRIVATE double-conversion)
 set_target_properties(json PROPERTIES PUBLIC_HEADER "json.h")
 
 # Tests
-add_executable(json_test json_test.cpp)
-target_link_libraries(json_test PRIVATE json)
+if (JSON_CPP_BUILD_TESTS)
+    add_executable(json_test json_test.cpp)
+    target_link_libraries(json_test PRIVATE json)
 
-add_executable(jsontestsuite_test jsontestsuite_test.cpp)
-target_link_libraries(jsontestsuite_test PRIVATE json)
+    add_executable(jsontestsuite_test jsontestsuite_test.cpp)
+    target_link_libraries(jsontestsuite_test PRIVATE json)
 
-# Copy test data to build directory
-add_custom_command(
-    TARGET jsontestsuite_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_SOURCE_DIR}/JSONTestSuite
-        ${CMAKE_CURRENT_BINARY_DIR}/JSONTestSuite
-)
+    # Copy test data to build directory
+    add_custom_command(
+        TARGET jsontestsuite_test POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/JSONTestSuite
+            ${CMAKE_CURRENT_BINARY_DIR}/JSONTestSuite
+    )
 
 enable_testing()
-add_test(NAME json_test COMMAND json_test)
-add_test(
-    NAME jsontestsuite_test 
-    COMMAND jsontestsuite_test
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-)
+    enable_testing()
+    add_test(NAME json_test COMMAND json_test)
+    add_test(
+        NAME jsontestsuite_test
+        COMMAND jsontestsuite_test
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+endif()
 
 install(TARGETS json double-conversion
     ARCHIVE DESTINATION lib


### PR DESCRIPTION
- Allow disabling tests
- Use CMAKE_CURRENT_SOURCE_DIR when copy JSONTestSuite