### PR TITLE
Add install directive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,3 +45,9 @@ add_test(
     COMMAND jsontestsuite_test
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+install(TARGETS json
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ add_test(
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-install(TARGETS json
+install(TARGETS json double-conversion
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(json STATIC
     json.cpp
 )
 target_link_libraries(json PRIVATE double-conversion)
+set_target_properties(json PROPERTIES PUBLIC_HEADER "json.h")
 
 # Tests
 add_executable(json_test json_test.cpp)
@@ -50,4 +51,5 @@ install(TARGETS json
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
+    PUBLIC_HEADER DESTINATION include
 )


### PR DESCRIPTION
I was using your library with my meson project.
I generated a pkg-config file for it and then it worked great once I had these install directives.

I will contribute to nixpkgs but my overlay had this for those that are interested.

```nix
json-cpp = prev.stdenv.mkDerivation (finalAttrs: {
              pname = "json.cpp";
              version = "0-unstable-2025-10-21";

              src = prev.fetchFromGitHub {
                owner = "fzakaria";
                repo = "json.cpp";
                rev = "f2306d5de0f8603797614f1cd6d8a3bd22e5b866";
                sha256 = "sha256-qYPS8+q6DAI22f08wVCtIsfP+rIGBYnB43zm8UJ7lZ8=";
              };

              nativeBuildInputs = [
                prev.cmake
                prev.copyPkgconfigItems
              ];

              pkgconfigItems = [
                (prev.makePkgconfigItem rec {
                  name = "json.cpp";
                  inherit (finalAttrs) version;
                  cflags = ["-I${variables.includedir}"];
                  libs = [
                    "-L${variables.libdir}"
                    "-ljson"
                    "-ldouble-conversion"
                  ];
                  variables = rec {
                    prefix = placeholder "out";
                    includedir = "${prefix}/include";
                    libdir = "${prefix}/lib";
                  };
                  inherit (finalAttrs.meta) description;
                })
              ];
            });
```

Here is what it built
```
tree /nix/store/9yc9civnsknn2yh67w3x3wgaaflxwydz-json.cpp-0-unstable-2025-10-21
/nix/store/9yc9civnsknn2yh67w3x3wgaaflxwydz-json.cpp-0-unstable-2025-10-21
├── include
│   └── json.h
└── lib
    ├── libdouble-conversion.a
    ├── libjson.a
    └── pkgconfig
        └── json.cpp.pc
```

```
includedir=/nix/store/9yc9civnsknn2yh67w3x3wgaaflxwydz-json.cpp-0-unstable-2025-10-21/include
libdir=/nix/store/9yc9civnsknn2yh67w3x3wgaaflxwydz-json.cpp-0-unstable-2025-10-21/lib
prefix=/nix/store/9yc9civnsknn2yh67w3x3wgaaflxwydz-json.cpp-0-unstable-2025-10-21

Cflags: -I/nix/store/9yc9civnsknn2yh67w3x3wgaaflxwydz-json.cpp-0-unstable-2025-10-21/include
Description: JSON C++
Libs: -L/nix/store/9yc9civnsknn2yh67w3x3wgaaflxwydz-json.cpp-0-unstable-2025-10-21/lib -ljson -ldouble-conversion
Name: json.cpp
Version: 0-unstable-2025-10-21
```