### PR TITLE
Improve CMake build for nixpkgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,25 +2,32 @@ cmake_minimum_required(VERSION 3.15)
 project(jtjson)
 
 option(JSON_CPP_BUILD_TESTS "Enable building tests" ON)
+option(DOUBLE_CONVERSION_VENDORED "Use vendored double-conversion library" ON)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Add double-conversion library
-add_library(double-conversion STATIC
-    double-conversion/bignum.cc
-    double-conversion/bignum-dtoa.cc
-    double-conversion/cached-powers.cc
-    double-conversion/double-to-string.cc
-    double-conversion/fast-dtoa.cc
-    double-conversion/fixed-dtoa.cc
-    double-conversion/string-to-double.cc
-    double-conversion/strtod.cc
-)
-target_include_directories(double-conversion PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+if (DOUBLE_CONVERSION_VENDORED)
+    # Add double-conversion library
+    add_library(double-conversion STATIC
+        double-conversion/bignum.cc
+        double-conversion/bignum-dtoa.cc
+        double-conversion/cached-powers.cc
+        double-conversion/double-to-string.cc
+        double-conversion/fast-dtoa.cc
+        double-conversion/fixed-dtoa.cc
+        double-conversion/string-to-double.cc
+        double-conversion/strtod.cc
+    )
+    target_include_directories(double-conversion PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+else()
+    find_package(double-conversion REQUIRED)
+endif()
 
 # Main JSON library
-add_library(json STATIC
+# BUILD_SHARED_LIBS is a standard CMake variable that
+# controls whether libraries are built as shared or static
+add_library(json
     json.cpp
 )
 target_link_libraries(json PRIVATE double-conversion)
@@ -52,9 +59,10 @@ enable_testing()
     )
 endif()
 
-install(TARGETS json double-conversion
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-    PUBLIC_HEADER DESTINATION include
+include(GNUInstallDirs)
+install(TARGETS json
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )


### PR DESCRIPTION
Improvements that make it easier to integrate with nixpkgs while still following CMake conventions.

* Allow library to be either static or shared dependent on BUILD_SHARED_LIBS which is the default option
* Added option to control whether to use vendored double-conversion
* Used GNUInstallDirs for common variables for install