### PR TITLE
add const access

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -521,6 +521,17 @@ Json::getString()
     }
 }
 
+const std::string&
+Json::getString() const
+{
+    switch (type_) {
+        case String:
+            return string_value;
+        default:
+            ON_LOGIC_ERROR("JSON value is not a string.");
+    }
+}
+
 std::vector<Json>&
 Json::getArray()
 {
@@ -532,8 +543,30 @@ Json::getArray()
     }
 }
 
+const std::vector<Json>&
+Json::getArray() const
+{
+    switch (type_) {
+        case Array:
+            return array_value;
+        default:
+            ON_LOGIC_ERROR("JSON value is not an array.");
+    }
+}
+
 std::map<std::string, Json>&
 Json::getObject()
+{
+    switch (type_) {
+        case Object:
+            return object_value;
+        default:
+            ON_LOGIC_ERROR("JSON value is not an object.");
+    }
+}
+
+const std::map<std::string, Json>&
+Json::getObject() const
 {
     switch (type_) {
         case Object:
@@ -580,12 +613,34 @@ Json::operator[](size_t index)
     return array_value[index];
 }
 
+const Json&
+Json::operator[](size_t index) const
+{
+    if (!isArray())
+        ON_LOGIC_ERROR("JSON value is not an array.");
+    if (index >= array_value.size()) {
+        ON_LOGIC_ERROR("JSON index not in array.");
+    }
+    return array_value[index];
+}
+
 Json&
 Json::operator[](const std::string& key)
 {
     if (!isObject())
         setObject();
     return object_value[key];
+}
+
+const Json&
+Json::operator[](const std::string& key) const
+{
+    if (!isObject())
+        ON_LOGIC_ERROR("JSON value is not an object.");
+    auto it = object_value.find(key);
+    if (it == object_value.end())
+        ON_LOGIC_ERROR("JSON object does not contain key.");
+    return it->second;
 }
 
 std::string

--- a/json.h
+++ b/json.h
@@ -190,8 +190,11 @@ class Json
     double getDouble() const;
     double getNumber() const;
     long long getLong() const;
+    const std::string& getString() const;
     std::string& getString();
+    const std::vector<Json>& getArray() const;
     std::vector<Json>& getArray();
+    const std::map<std::string, Json>& getObject() const;
     std::map<std::string, Json>& getObject();
 
     bool contains(const std::string&) const;
@@ -206,7 +209,9 @@ class Json
     Json& operator=(Json&&);
 
     Json& operator[](size_t);
+    const Json& operator[](size_t) const;
     Json& operator[](const std::string&);
+    const Json& operator[](const std::string&) const;
 
     operator std::string() const
     {


### PR DESCRIPTION
It's not really necessary, but would be nice to have. The use case for me is the JSON object being part of a struct, and I have a bunch of `const` methods for the outer struct.

```c++
class Foo {
   jt::Json info;

   public:
        double getObj1A() { return info["obj1"].getNumber(); } // works
        double getObj1B() const { return info["obj1"].getNumber(); } // should work with this PR
        const std::vector<jt::Json>& getObj2() const { 
            return info["obj2"].getArray(); // should work with this PR
        }
}
```
